### PR TITLE
Exposing extra types

### DIFF
--- a/src/Playground.elm
+++ b/src/Playground.elm
@@ -22,7 +22,6 @@ module Playground exposing
   --
   , Computer
   , Mouse
-  , Screen
   , Keyboard
   , toX
   , toY
@@ -35,6 +34,11 @@ module Playground exposing
   , white, lightGrey, grey, darkGrey, lightCharcoal, charcoal, darkCharcoal, black
   , rgb
   , lightGray, gray, darkGray
+  --
+  , Screen
+  , Animation
+  , Game
+  , Msg
   )
 
 {-|


### PR DESCRIPTION
Some type is not exposed causing the type signature of main to fail.

Related to https://github.com/evancz/elm-playground/issues/9