### PR TITLE
Fix error in example about `polygon`

### DIFF
--- a/src/Playground.elm
+++ b/src/Playground.elm
@@ -973,7 +973,7 @@ octagon color radius =
 
     main =
       picture
-        [ polygon [ (-10,-20), (0,100), (10,-20) ]
+        [ polygon black [ (-10,-20), (0,100), (10,-20) ]
         ]
 
 **Note:** If you [`rotate`](#rotate) a polygon, it will always rotate around


### PR DESCRIPTION
Add a color (black) to the example of `polygon`

<img width="666" alt="Screen Shot 2019-10-22 at 9 20 05" src="https://user-images.githubusercontent.com/5551094/67252374-8cc8cc00-f4ad-11e9-86b1-7278727305dc.png">
